### PR TITLE
Invalid character : in log stream name

### DIFF
--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -220,6 +220,7 @@ Resources:
               sed -i "s|%ECS_CLUSTER|\$ECS_CLUSTER|g" /var/awslogs/etc/awslogs.conf
               sed -i "s|%CONTAINER_INSTANCE|\$CONTAINER_INSTANCE|g" /var/awslogs/etc/awslogs.conf
               chkconfig awslogs on
+              service awslogs stop
               service awslogs start
               end script
               EOF

--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -216,7 +216,7 @@ Resources:
               until curl -s http://localhost:51678/v1/metadata; do sleep 1; done
               ECS_CLUSTER=\$(curl -s http://localhost:51678/v1/metadata | jq .Cluster | tr-d \")
               CONTAINER_INSTANCE=\$(curl -s http://localhost:51678/v1/metadata | jq .ContainerInstanceArn| tr -d \")
-              CONTAINER_INSTANCE=\$(echo $CONTAINER_INSTANCE | sed "s|\:|_|g")
+              CONTAINER_INSTANCE=\$(echo \$CONTAINER_INSTANCE | sed "s|\:|_|g")
               sed -i "s|%ECS_CLUSTER|\$ECS_CLUSTER|g" /var/awslogs/etc/awslogs.conf
               sed -i "s|%CONTAINER_INSTANCE|\$CONTAINER_INSTANCE|g" /var/awslogs/etc/awslogs.conf
               chkconfig awslogs on

--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -216,9 +216,9 @@ Resources:
               until curl -s http://localhost:51678/v1/metadata; do sleep 1; done
               ECS_CLUSTER=\$(curl -s http://localhost:51678/v1/metadata | jq .Cluster | tr-d \")
               CONTAINER_INSTANCE=\$(curl -s http://localhost:51678/v1/metadata | jq .ContainerInstanceArn| tr -d \")
+              CONTAINER_INSTANCE=\$(echo $CONTAINER_INSTANCE | sed "s|\:|_|g")
               sed -i "s|%ECS_CLUSTER|\$ECS_CLUSTER|g" /var/awslogs/etc/awslogs.conf
               sed -i "s|%CONTAINER_INSTANCE|\$CONTAINER_INSTANCE|g" /var/awslogs/etc/awslogs.conf
-              sed -i "s|\:|_|g" /var/awslogs/etc/awslogs.conf
               chkconfig awslogs on
               service awslogs start
               end script

--- a/templates/ecs-cluster.yaml
+++ b/templates/ecs-cluster.yaml
@@ -218,6 +218,7 @@ Resources:
               CONTAINER_INSTANCE=\$(curl -s http://localhost:51678/v1/metadata | jq .ContainerInstanceArn| tr -d \")
               sed -i "s|%ECS_CLUSTER|\$ECS_CLUSTER|g" /var/awslogs/etc/awslogs.conf
               sed -i "s|%CONTAINER_INSTANCE|\$CONTAINER_INSTANCE|g" /var/awslogs/etc/awslogs.conf
+              sed -i "s|\:|_|g" /var/awslogs/etc/awslogs.conf
               chkconfig awslogs on
               service awslogs start
               end script


### PR DESCRIPTION
Convert : to _ in Log stream name because they are not valid
Restart the awslog service, it is started by something else before the replacement of the variables is made.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
